### PR TITLE
`--color` option is not necessary.

### DIFF
--- a/features/GettingStarted.md
+++ b/features/GettingStarted.md
@@ -69,7 +69,7 @@ end
 Run the example and bask in the joy that is green.
 
 <pre style="color:green;">
-$ rspec game_spec.rb --color --format doc
+$ rspec game_spec.rb --format doc
 
 Game
   #score


### PR DESCRIPTION
Default output is colored.  And  there is `no-color` option to disable `color ` as follows.
So I think color option is not necessary.

```
--no-color, --no-colour        Force the output to not be in color, even if the output is a TTY
```